### PR TITLE
Fixes for mocoeffs

### DIFF
--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -336,12 +336,12 @@ class QChem(logfileparser.Logfile):
                 self.mocoeffs = []
             mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_alpha))
             self.parse_matrix(inputfile, mocoeffs)
-            self.mocoeffs.append(mocoeffs)
+            self.mocoeffs.append(mocoeffs.transpose())
 
         if 'Final Beta MO Coefficients' in line:
             mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_beta))
             self.parse_matrix(inputfile, mocoeffs)
-            self.mocoeffs.append(mocoeffs)
+            self.mocoeffs.append(mocoeffs.transpose())
 
         if 'Total energy in the final basis set' in line:
             if not hasattr(self, 'scfenergies'):
@@ -827,7 +827,7 @@ class QChem(logfileparser.Logfile):
             # Only use these MO coefficients if we don't have them
             # from `scf_final_print`.
             if len(self.mocoeffs) == 0:
-                self.mocoeffs.append(mocoeffs)
+                self.mocoeffs.append(mocoeffs.transpose())
 
             # Go back through `aonames` to create `atombasis`.
             assert len(self.aonames) == self.nbasis
@@ -841,7 +841,7 @@ class QChem(logfileparser.Logfile):
             mocoeffs = numpy.empty(shape=(self.nbasis, self.norbdisp_beta_aonames))
             self.parse_matrix_aonames(inputfile, mocoeffs)
             if len(self.mocoeffs) == 1:
-                self.mocoeffs.append(mocoeffs)
+                self.mocoeffs.append(mocoeffs.transpose())
 
         # Population analysis.
 

--- a/src/cclib/parser/qchemparser.py
+++ b/src/cclib/parser/qchemparser.py
@@ -91,6 +91,20 @@ class QChem(logfileparser.Logfile):
                                   if len(coords) == correctlen]
         # At the moment, there is no similar correction for other properties!
 
+        # QChem does not print all MO coefficients by default, but rather
+        # up to HOMO+5. So, fill up the missing values with NaNs. If there are
+        # other cases where coefficient are missing, but different ones, this
+        # general afterthought might not be appropriate and the fix will
+        # need to be done while parsing.
+        if hasattr(self, 'mocoeffs'):
+            for im in range(len(self.mocoeffs)):
+                _nmo, _nbasis = self.mocoeffs[im].shape
+                if (_nmo, _nbasis) != (self.nmo, self.nbasis):
+                    coeffs = numpy.empty((self.nmo, self.nbasis))
+                    coeffs[:] = numpy.nan
+                    coeffs[0:_nmo, 0:_nbasis] = self.mocoeffs[im]
+                    self.mocoeffs[im] = coeffs
+
     def extract(self, inputfile, line):
         """Extract information from the file object inputfile."""
 

--- a/test/regression.py
+++ b/test/regression.py
@@ -468,9 +468,9 @@ def testQChem_QChem4_2_CO2_out(logfile):
     assert logfile.data.nbasis == nbasis
     assert logfile.data.nmo == nmo
     assert len(logfile.data.mocoeffs) == 1
-    assert logfile.data.mocoeffs[0].shape == (nbasis, nalpha + 5)
+    assert logfile.data.mocoeffs[0].shape == (nmo, nbasis)
     assert logfile.data.mocoeffs[0][0, 0] == -0.0001434
-    assert logfile.data.mocoeffs[0][-1, -1] == -0.0000661
+    assert logfile.data.mocoeffs[0][nalpha + 5 - 1, nbasis - 1] == -0.0000661
     assert len(logfile.data.moenergies) == 1
     assert len(logfile.data.moenergies[0]) == nmo
 
@@ -484,12 +484,12 @@ def testQChem_QChem4_2_CO2_cation_UHF_out(logfile):
     assert logfile.data.nbasis == nbasis
     assert logfile.data.nmo == nmo
     assert len(logfile.data.mocoeffs) == 2
-    assert logfile.data.mocoeffs[0].shape == (nbasis, nalpha + 5)
-    assert logfile.data.mocoeffs[1].shape == (nbasis, nbeta + 5)
+    assert logfile.data.mocoeffs[0].shape == (nmo, nbasis)
+    assert logfile.data.mocoeffs[1].shape == (nmo, nbasis)
     assert logfile.data.mocoeffs[0][0, 0] == -0.0001549
-    assert logfile.data.mocoeffs[0][-1, -1] == -0.0000985
+    assert logfile.data.mocoeffs[0][nalpha + 5 - 1, nbasis - 1] == -0.0000985
     assert logfile.data.mocoeffs[1][0, 0] == -0.0001612
-    assert logfile.data.mocoeffs[1][-1, -1] == -0.0027710
+    assert logfile.data.mocoeffs[1][nbeta + 5 - 1, nbasis - 1] == -0.0027710
     assert len(logfile.data.moenergies) == 2
     assert len(logfile.data.moenergies[0]) == nmo
     assert len(logfile.data.moenergies[1]) == nmo
@@ -504,12 +504,12 @@ def testQChem_QChem4_2_CO2_cation_ROHF_bigprint_allvirt_out(logfile):
     assert logfile.data.nbasis == nbasis
     assert logfile.data.nmo == nmo
     assert len(logfile.data.mocoeffs) == 2
-    assert logfile.data.mocoeffs[0].shape == (nbasis, nalpha + 5)
-    assert logfile.data.mocoeffs[1].shape == (nbasis, nbeta + 5)
+    assert logfile.data.mocoeffs[0].shape == (nmo, nbasis)
+    assert logfile.data.mocoeffs[1].shape == (nmo, nbasis)
     assert logfile.data.mocoeffs[0][0, 0] == -0.0001543
-    assert logfile.data.mocoeffs[0][-1, -3] == -0.0132848
-    assert logfile.data.mocoeffs[1][0, 2] == 0.9927881
-    assert logfile.data.mocoeffs[1][-1, -1] == 0.0018019
+    assert logfile.data.mocoeffs[0][nalpha + 5 - 3, nbasis - 1] == -0.0132848
+    assert logfile.data.mocoeffs[1][2, 0] == 0.9927881
+    assert logfile.data.mocoeffs[1][nbeta + 5 - 1, nbasis - 1] == 0.0018019
     assert len(logfile.data.moenergies) == 2
     assert len(logfile.data.moenergies[0]) == nmo
     assert len(logfile.data.moenergies[1]) == nmo

--- a/test/testSP.py
+++ b/test/testSP.py
@@ -308,16 +308,6 @@ class Psi3SPTest(PsiSPTest):
 class QChemSPTest(GenericSPTest):
     """Customized restricted single point unittest"""
 
-    # By default, Q-Chem doesn't print out an nbasis * nmo dim MO
-    # coefficient matrix, but a nbasis * (nocc + 5) * nbasis matrix.
-    def testdimmocoeffs(self):
-        """Are the dimensions of mocoeffs equal to 1 x nbasis x (nocc + 5)?"""
-        ncols = self.data.homos[0] + 1 + 5
-        self.assertEquals(type(self.data.mocoeffs), type([]))
-        self.assertEquals(len(self.data.mocoeffs), 1)
-        self.assertEquals(self.data.mocoeffs[0].shape,
-                          (self.data.nbasis, ncols))
-
     # Q-Chem cannot print the overlap matrix.
     def testdimaooverlaps(self):
         """Are the dims of the overlap matrix consistent with nbasis? PASS"""

--- a/test/testSPun.py
+++ b/test/testSPun.py
@@ -159,20 +159,7 @@ class OrcaSPunTest(GenericSPunTest):
 class QChemSPunTest(GenericSPunTest):
     """Customized unrestricted single point unittest"""
 
-    # By default, Q-Chem doesn't print out an nbasis * nmo dim MO
-    # coefficient matrix, but a nbasis * (nocc + 5) * nbasis matrix.
-    def testdimmocoeffs(self):
-        """Are the dimensions of mocoeffs equal to 2 x nbasis x (nocc + 5)?"""
-        ncols_a = self.data.homos[0] + 1 + 5
-        ncols_b = self.data.homos[1] + 1 + 5
-        self.assertEquals(type(self.data.mocoeffs), type([]))
-        self.assertEquals(len(self.data.mocoeffs), 2)
-        self.assertEquals(self.data.mocoeffs[0].shape,
-                          (self.data.nbasis, ncols_a))
-        self.assertEquals(self.data.mocoeffs[1].shape,
-                          (self.data.nbasis, ncols_b))
-
-        # Q-Chem cannot print the overlap matrix.
+    # Q-Chem cannot print the overlap matrix.
     def testdimaooverlaps(self):
         """Are the dims of the overlap matrix consistent with nbasis? PASS"""
 


### PR DESCRIPTION
These commits fix the shape and orientation of `mocoeffs`, filling it up with NaNs after parsing, if needed. If this is the only scenario where coefficients may be missing, this should be sufficient.